### PR TITLE
REFACTOR: update to Glimmer, fix `currentStatus`, add tests

### DIFF
--- a/javascripts/discourse/components/unanswered-filter.hbs
+++ b/javascripts/discourse/components/unanswered-filter.hbs
@@ -1,8 +1,8 @@
-{{#unless staffOnly}}
-  {{#if shouldRender}}
+{{#unless this.staffOnly}}
+  {{#if this.shouldRender}}
     {{combo-box
-      content=statuses
-      value=queryStatus
+      content=this.statuses
+      value=this.currentStatus
       valueAttribute="value"
       onSelect=(action "changeStatus")
       class="topic-unanswered-filter-dropdown"

--- a/javascripts/discourse/components/unanswered-filter.js
+++ b/javascripts/discourse/components/unanswered-filter.js
@@ -30,7 +30,7 @@ export default class UnansweredFilter extends Component {
       Object.keys(this.statusToQueryParam).find((key) =>
         this.statusToQueryParam[key]
           ? queryStrings.includes(this.statusToQueryParam[key])
-          : false,
+          : false
       ) || "all";
   }
 
@@ -39,7 +39,7 @@ export default class UnansweredFilter extends Component {
       ? queryStrings.substring(1).split("&")
       : [];
     return params.filter(
-      (param) => !Object.values(this.statusToQueryParam).includes(param),
+      (param) => !Object.values(this.statusToQueryParam).includes(param)
     );
   }
 

--- a/javascripts/discourse/components/unanswered-filter.js
+++ b/javascripts/discourse/components/unanswered-filter.js
@@ -1,69 +1,72 @@
-import { action } from "@ember/object";
 import Component from "@ember/component";
-import discourseComputed from "discourse-common/utils/decorators";
+import { action } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
 import DiscourseURL from "discourse/lib/url";
 import { inject as service } from "@ember/service";
 import I18n from "I18n";
 
-export default Component.extend({
-  router: service(),
+export default class UnansweredFilter extends Component {
+  @service router;
+  @service currentUser;
+  @tracked currentStatus = null;
+  @tracked statuses = ["all", "answered", "unanswered"].map((status) => ({
+    name: I18n.t(themePrefix(`topic_answered_filter.${status}`)),
+    value: status,
+  }));
+  statusToQueryParam = {
+    all: "",
+    answered: "min_posts=2",
+    unanswered: "max_posts=1",
+  };
 
-  statuses: ["all", "answered", "unanswered"].map((status) => {
-    return {
-      name: I18n.t(themePrefix(`topic_answered_filter.${status}`)),
-      value: status,
-    };
-  }),
+  constructor() {
+    super(...arguments);
+    this.updateStatusFromQuery(window.location.search);
+  }
 
-  @discourseComputed
-  queryStatus() {
-    let queryStrings = window.location.search;
-    if (queryStrings.match(/min_posts=2/)) {
-      return "answered";
-    } else if (queryStrings.match(/max_posts=1/)) {
-      return "unanswered";
-    } else {
-      return "all";
-    }
-  },
+  updateStatusFromQuery(queryStrings) {
+    this.currentStatus =
+      Object.keys(this.statusToQueryParam).find((key) =>
+        this.statusToQueryParam[key]
+          ? queryStrings.includes(this.statusToQueryParam[key])
+          : false,
+      ) || "all";
+  }
 
-  @discourseComputed("router.currentRouteName", "router.currentURL")
-  shouldRender(currentRouteName, currentURL) {
-    let exclusions = settings.exclusions.split("|");
-    if (currentRouteName !== "discovery.categories") {
-      return !exclusions.includes(currentURL);
-    }
-  },
-
-  @discourseComputed("currentUser")
-  staffOnly(currentUser) {
-    const notStaff =
-      (!currentUser || (currentUser && !currentUser.staff)) &&
-      settings.show_only_for_staff;
-    return notStaff;
-  },
-
-  @action
-  changeStatus(newStatus) {
-    let location = window.location;
-    let queryStrings = location.search;
+  getFilteredParams(queryStrings) {
     let params = queryStrings.startsWith("?")
       ? queryStrings.substring(1).split("&")
       : [];
+    return params.filter(
+      (param) => !Object.values(this.statusToQueryParam).includes(param),
+    );
+  }
 
-    params = params.filter((param) => {
-      return !param.startsWith("max_posts=") && !param.startsWith("min_posts=");
-    });
-
-    if (newStatus && newStatus !== "all") {
-      if (newStatus === "unanswered") {
-        params.push(`max_posts=1`);
-      } else if (newStatus === "answered") {
-        params.push(`min_posts=2`);
-      }
+  get shouldRender() {
+    let exclusions = settings.exclusions.split("|");
+    if (this.router.currentRouteName !== "discovery.categories") {
+      return !exclusions.includes(this.router.currentURL);
     }
+  }
 
-    queryStrings = params.length > 0 ? `?${params.join("&")}` : "";
-    DiscourseURL.routeTo(`${location.pathname}${queryStrings}${location.hash}`);
-  },
-});
+  get staffOnly() {
+    const notStaff =
+      (!this.currentUser || (this.currentUser && !this.currentUser.staff)) &&
+      settings.show_only_for_staff;
+    return notStaff;
+  }
+
+  @action
+  changeStatus(newStatus) {
+    const { search, pathname, hash } = window.location;
+    let params = this.getFilteredParams(search);
+    newStatus &&
+      newStatus !== "all" &&
+      params.push(this.statusToQueryParam[newStatus]);
+    const queryStrings = params.length ? `?${params.join("&")}` : "";
+
+    DiscourseURL.routeTo(`${pathname}${queryStrings}${hash}`);
+
+    this.currentStatus = newStatus;
+  }
+}

--- a/javascripts/discourse/components/unanswered-filter.js
+++ b/javascripts/discourse/components/unanswered-filter.js
@@ -13,6 +13,7 @@ export default class UnansweredFilter extends Component {
     name: I18n.t(themePrefix(`topic_answered_filter.${status}`)),
     value: status,
   }));
+
   statusToQueryParam = {
     all: "",
     answered: "min_posts=2",

--- a/javascripts/discourse/connectors/bread-crumbs-right/unanswered-filter-connector.hbs
+++ b/javascripts/discourse/connectors/bread-crumbs-right/unanswered-filter-connector.hbs
@@ -1,1 +1,1 @@
-{{unanswered-filter}}
+<UnansweredFilter />

--- a/test/acceptance/unanswered-filter-test.js
+++ b/test/acceptance/unanswered-filter-test.js
@@ -29,8 +29,8 @@ acceptance("Unanswered Filter - logged out", function () {
 
     assert.ok(
       query(".topic-unanswered-filter-dropdown .name").innerText.includes(
-        "answered",
-      ),
+        "answered"
+      )
     );
     stub.restore();
   });
@@ -46,8 +46,8 @@ acceptance("Unanswered Filter - logged out", function () {
 
     assert.ok(
       query(".topic-unanswered-filter-dropdown .name").innerText.includes(
-        "unanswered",
-      ),
+        "unanswered"
+      )
     );
     stub.restore();
   });

--- a/test/acceptance/unanswered-filter-test.js
+++ b/test/acceptance/unanswered-filter-test.js
@@ -1,0 +1,89 @@
+import {
+  acceptance,
+  query,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import sinon from "sinon";
+import UnansweredFilter from "../../discourse/components/unanswered-filter";
+
+acceptance("Unanswered Filter - logged out", function () {
+  settings.show_only_for_staff = false;
+
+  test("Unanswered filter appears", async function (assert) {
+    await visit("/latest");
+    assert
+      .dom(".topic-unanswered-filter-dropdown")
+      .exists("Unanswered filter exists");
+  });
+
+  test("Filter value is answered", async function (assert) {
+    let stub = sinon
+      .stub(UnansweredFilter.prototype, "updateStatusFromQuery")
+      .callsFake(function () {
+        this.currentStatus = "answered";
+      });
+
+    await visit("/latest");
+
+    assert.ok(
+      query(".topic-unanswered-filter-dropdown .name").innerText.includes(
+        "answered",
+      ),
+    );
+    stub.restore();
+  });
+
+  test("Filter value is unanswered", async function (assert) {
+    let stub = sinon
+      .stub(UnansweredFilter.prototype, "updateStatusFromQuery")
+      .callsFake(function () {
+        this.currentStatus = "unanswered";
+      });
+
+    await visit("/latest");
+
+    assert.ok(
+      query(".topic-unanswered-filter-dropdown .name").innerText.includes(
+        "unanswered",
+      ),
+    );
+    stub.restore();
+  });
+
+  test("Filter does not appear on excluded route", async function (assert) {
+    settings.exclusions = "/top";
+
+    await visit("/top");
+    assert
+      .dom(".topic-unanswered-filter-dropdown")
+      .doesNotExist("Unanswered filter does not appear");
+  });
+
+  test("Filter does not appear for anon when the staff setting is enabled", async function (assert) {
+    settings.show_only_for_staff = true;
+
+    await visit("/latest");
+    assert
+      .dom(".topic-unanswered-filter-dropdown")
+      .doesNotExist("Unanswered filter does not appear");
+  });
+});
+
+acceptance("Unanswered Filter - logged in", function (needs) {
+  needs.user();
+
+  test("Filter appears for staff when the staff setting is enabled", async function (assert) {
+    settings.show_only_for_staff = true;
+
+    updateCurrentUser({
+      staff: true,
+    });
+
+    await visit("/latest");
+    assert
+      .dom(".topic-unanswered-filter-dropdown")
+      .exists("Unanswered filter appears only for staff");
+  });
+});


### PR DESCRIPTION
![Screenshot 2023-10-16 at 1 00 34 PM](https://github.com/discourse/discourse-unanswered-filter/assets/1681963/ed7dd5eb-3c48-400c-aacb-e17cffdb2b67)


A customer has reported that the status no longer updates in the dropdown, despite the URL changing and the topics being filtered. I believe this was a case where the component was relying on the loading route to destroy it and the loading slider broke this. Updating to a tracked property using Glimmer fixes it. 

