### PR TITLE
UX: do not render in category settings

### DIFF
--- a/javascripts/discourse/components/unanswered-filter-dropdown.gjs
+++ b/javascripts/discourse/components/unanswered-filter-dropdown.gjs
@@ -47,6 +47,7 @@ export default class UnansweredFilterDropdown extends Component {
 
   get shouldRender() {
     return (
+      this.router.currentRouteName !== "editCategory.tabs" &&
       this.router.currentRouteName !== "discovery.categories" &&
       !settings.exclusions.split("|").includes(this.router.currentURL) &&
       this.isGroupMember


### PR DESCRIPTION
For some reason this started rendering in category settings, this removes it 

Before:

![image](https://github.com/discourse/discourse-unanswered-filter/assets/1681963/67edbeb5-f53d-4525-b484-c3c3acf0ea68)



After:

![image](https://github.com/discourse/discourse-unanswered-filter/assets/1681963/cccad528-2a2f-444e-acac-76bf6370e9dd)
