### PR TITLE
DEV: Add group-based setting metadata

### DIFF
--- a/javascripts/discourse/components/unanswered-filter-dropdown.gjs
+++ b/javascripts/discourse/components/unanswered-filter-dropdown.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import { AUTO_GROUPS } from "discourse/lib/constants";
 import ComboBox from "discourse/select-kit/components/combo-box";
 import { i18n } from "discourse-i18n";
 
@@ -32,16 +33,28 @@ export default class UnansweredFilterDropdown extends Component {
   }
 
   get isGroupMember() {
+    if (Object.hasOwn(settings, "user_in_limit_to_groups")) {
+      return settings.user_in_limit_to_groups;
+    }
+
+    // TODO (martin) Remove this fallback after resolve_group_membership
+    // from core is available everywhere
     const groupInclusions = settings.limit_to_groups
       .split("|")
       .map((id) => parseInt(id, 10));
+
+    // NOTE: The default for this setting was changed to "4|5" in the theme settings,
+    // since that is what now represents all anon + logged in users, so this fallback is
+    // for backwards compatibility.
+    const noLimitToGroups =
+      !settings.limit_to_groups || settings.limit_to_groups === "4|5";
 
     return (
       this.currentUser?.groups?.some((group) =>
         groupInclusions.includes(group.id)
       ) ||
-      groupInclusions.includes(0) ||
-      !settings.limit_to_groups
+      groupInclusions.includes(AUTO_GROUPS.everyone.id) ||
+      noLimitToGroups
     );
   }
 

--- a/javascripts/discourse/initializers/unanswered-filter.js
+++ b/javascripts/discourse/initializers/unanswered-filter.js
@@ -1,4 +1,5 @@
 import { apiInitializer } from "discourse/lib/api";
+import { AUTO_GROUPS } from "discourse/lib/constants";
 import { i18n } from "discourse-i18n";
 import UnansweredFilterDropdown from "../components/unanswered-filter-dropdown";
 
@@ -9,14 +10,28 @@ export default apiInitializer((api) => {
   }
 
   const exclusionList = settings.exclusions.split("|");
-  const currentUser = api.getCurrentUser();
-  const groupInclusions = settings.limit_to_groups
-    .split("|")
-    .map((id) => parseInt(id, 10));
 
-  const isGroupMember =
-    currentUser?.groups?.some((group) => groupInclusions.includes(group.id)) ||
-    groupInclusions.includes(0);
+  // NOTE: The default for this setting was changed to "4|5" in the theme settings,
+  // since that is what now represents all anon + logged in users, so this fallback is
+  // for backwards compatibility.
+  const noLimitToGroups =
+    !settings.limit_to_groups || settings.limit_to_groups === "4|5";
+
+  let isGroupMember = false;
+  if (Object.hasOwn(settings, "user_in_limit_to_groups")) {
+    isGroupMember = settings.user_in_limit_to_groups;
+  } else {
+    const currentUser = api.getCurrentUser();
+    const groupInclusions = settings.limit_to_groups
+      .split("|")
+      .map((id) => parseInt(id, 10));
+    // TODO (martin) Remove this fallback after resolve_group_membership
+    // from core is available everywhere
+    isGroupMember =
+      currentUser?.groups?.some((group) =>
+        groupInclusions.includes(group.id)
+      ) || groupInclusions.includes(AUTO_GROUPS.everyone.id);
+  }
 
   api.addNavigationBarItem({
     name: "unanswered",
@@ -26,7 +41,7 @@ export default apiInitializer((api) => {
     customFilter: (category, args, router) => {
       return (
         !exclusionList.includes(router.currentURL) &&
-        (isGroupMember || !settings.limit_to_groups)
+        (isGroupMember || noLimitToGroups)
       );
     },
 

--- a/javascripts/discourse/initializers/unanswered-filter.js
+++ b/javascripts/discourse/initializers/unanswered-filter.js
@@ -11,12 +11,6 @@ export default apiInitializer((api) => {
 
   const exclusionList = settings.exclusions.split("|");
 
-  // NOTE: The default for this setting was changed to "4|5" in the theme settings,
-  // since that is what now represents all anon + logged in users, so this fallback is
-  // for backwards compatibility.
-  const noLimitToGroups =
-    !settings.limit_to_groups || settings.limit_to_groups === "4|5";
-
   let isGroupMember = false;
   if (Object.hasOwn(settings, "user_in_limit_to_groups")) {
     isGroupMember = settings.user_in_limit_to_groups;
@@ -39,10 +33,21 @@ export default apiInitializer((api) => {
     title: i18n(themePrefix("unanswered.help")),
 
     customFilter: (category, args, router) => {
-      return (
-        !exclusionList.includes(router.currentURL) &&
-        (isGroupMember || noLimitToGroups)
-      );
+      if (Object.hasOwn(settings, "user_in_limit_to_groups")) {
+        return !exclusionList.includes(router.currentURL) && isGroupMember;
+      } else {
+        // NOTE: The default for this setting was changed to "4|5" in the theme settings,
+        // since that is what now represents all anon + logged in users, so this fallback is
+        // for backwards compatibility.
+        //
+        // settings.limit_to_groups is undefined if user_in_limit_to_groups is defined
+        const noLimitToGroups =
+          !settings.limit_to_groups || settings.limit_to_groups === "4|5";
+        return (
+          !exclusionList.includes(router.currentURL) &&
+          (isGroupMember || noLimitToGroups)
+        );
+      }
     },
 
     customHref: function (category, args, router) {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,4 +8,4 @@ en:
     help: "Topics that have not been answered"
   theme_metadata:
     settings:
-      limit_to_groups: only show the filter for members of these groups
+      limit_to_groups: Only show the filter for members of these groups.

--- a/migrations/settings/0002-migrate-blank-limit-to-groups.js
+++ b/migrations/settings/0002-migrate-blank-limit-to-groups.js
@@ -1,0 +1,10 @@
+export default function migrate(settings) {
+  if (
+    settings.has("limit_to_groups") &&
+    !String(settings.get("limit_to_groups") ?? "").trim()
+  ) {
+    settings.set("limit_to_groups", "4|5");
+  }
+
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -15,9 +15,10 @@ exclusions:
       liking."
 
 limit_to_groups:
-  default: ""
+  default: "4|5"
   type: list
   list_type: group
+  resolve_group_membership: true
 
 filter_mode:
   type: enum

--- a/spec/system/logged_in_link_spec.rb
+++ b/spec/system/logged_in_link_spec.rb
@@ -52,8 +52,7 @@ RSpec.describe "Unanswered Filter Component - logged-in link test", system: true
 
     expect(page).to have_css(".nav-item_unanswered")
 
-    theme.update_setting(:filter_mode, "link")
-    theme.update_setting(:limit_to_groups, "#{group.id + 1}")
+    group_user.destroy!
     theme.save!
 
     visit(category.url)


### PR DESCRIPTION
Since the introduction of `resolve_group_membership` and
`disallowed_groups` metadata in [discourse/discourse#41792](https://github.com/discourse/discourse/pull/41792),
[discourse/discourse#41756](https://github.com/discourse/discourse/pull/41756), and [discourse/discourse-copy-post#37](https://github.com/discourse/discourse-copy-post/pull/37),
we are updating existing theme components to take advantage
of these new APIs in an effort to support the removal of the `everyone`
pseudogroup from core and increase clarity around group-based settings.

See also https://meta.discourse.org/t/-/402273
